### PR TITLE
Strengthen path validation to prevent path traversal via null bytes and ensure a

### DIFF
--- a/lxc_autoscale/ui/lxc_autoscale_ui.py
+++ b/lxc_autoscale/ui/lxc_autoscale_ui.py
@@ -27,10 +27,29 @@ _CONTROL_CHARS_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
 
 
 def _safe_path(path: str, allowed_dir: str = '/var/log') -> str:
-    """Resolve symlinks and verify the path stays within allowed_dir."""
+    """Resolve symlinks and verify the path stays within allowed_dir.
+    
+    Explicitly rejects:
+    - Relative paths (e.g., '../etc/passwd')
+    - Paths containing null bytes
+    - Paths resolving outside allowed_dir
+    """
+    # Reject null bytes in path (prevents null-byte truncation attacks)
+    if '\x00' in path:
+        raise ValueError(f"Path contains null byte: {repr(path)}")
+    
+    # Reject relative paths explicitly
+    if not os.path.isabs(path):
+        raise ValueError(f"Path must be absolute: {path}")
+    
+    # Resolve symlinks and get canonical path
     real = os.path.realpath(path)
-    if not real.startswith(os.path.realpath(allowed_dir) + os.sep):
+    
+    # Ensure resolved path is within allowed_dir
+    allowed_real = os.path.realpath(allowed_dir)
+    if not real.startswith(allowed_real + os.sep) and real != allowed_real:
         raise ValueError(f"Path escapes allowed directory: {path}")
+    
     return real
 
 


### PR DESCRIPTION
### FabGPT — code quality

**File:** `lxc_autoscale/ui/lxc_autoscale_ui.py`

**Rationale:** The current `_safe_path` function only uses `os.path.realpath()` and prefix checking, which is insufficient against path traversal attacks involving null bytes (e.g., `/var/log/../../../etc/passwd\x00.log`) or relative paths that resolve outside the allowed directory. Explicitly rejecting relative paths and null bytes ensures robust protection against such attacks.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `523dca1048b8990c` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"523dca1048b8990c","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":2,"inference_s":39.37,"prompt_sha":"812e9f05ff9b8385","triage":"WARN"} -->