### PR TITLE
ci: use a versioning-strategy that pip actually accepts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     # Requirements are declared as ranges on purpose: an install always gets
-    # the newest compatible release. Only widen a range when a new version
+    # the newest compatible release. Only touch a range when a new version
     # falls outside it, instead of raising the lower bound every week.
-    versioning-strategy: widen
+    # pip does not accept "widen"; this is the equivalent it does accept.
+    versioning-strategy: increase-if-necessary
     groups:
       pip:
         patterns:


### PR DESCRIPTION
Follow-up to #54.

Dependabot rejected the whole config file after that merge:

```
The property '#/updates/1/versioning-strategy' value "widen" did not match one of the following values: lockfile-only, auto, increase, increase-if-necessary
```

`widen` is valid for some ecosystems but not for pip. While the file was invalid Dependabot was not running at all, for any ecosystem in it.

`increase-if-necessary` has the semantics that was intended: the requirement is only touched when a new release falls outside the declared range, instead of raising the lower bound every week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)