### PR TITLE
fix: stop handing the same static IP to every clone (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Horizontal scaling handed the same static IP to every clone** ([#70](https://github.com/fabriziosalmi/proxmox-lxc-autoscale/issues/70)): the filter that was meant to skip addresses already in use compared IP strings against the list of integer container ids, so it never excluded anything and every clone received `static_ip_range[0]`. Addresses in use are now read from the live `net0` of each group member. The address is also chosen before the clone rather than after, so an exhausted range skips the scale-out instead of leaving behind a clone that could not be configured. Entries in `static_ip_range` may now carry their own prefix; bare addresses keep the documented `/24` default.
+
 ### Security
 - **Documentation toolchain**: cleared all 8 open Dependabot alerts in `docs/`. postcss moved to 8.5.26 and vite to 6.4.3 through `overrides`, which also pulls esbuild out of the vulnerable range. All three advisories concern the local dev server, not the static site that is deployed, but there is no reason to keep them. VitePress stays on 1.6.4, the current stable release; forcing vite 8 or esbuild 0.28 breaks the build.
 

--- a/docs/guide/horizontal-scaling.md
+++ b/docs/guide/horizontal-scaling.md
@@ -31,7 +31,7 @@ HORIZONTAL_SCALING_GROUP_1:
 ## How it works
 
 1. **Metrics** — Average CPU and memory usage are calculated across all containers in the group.
-2. **Scale out** — If averages exceed the upper thresholds, a new container is cloned from the base snapshot.
+2. **Scale out** — If averages exceed the upper thresholds, a new container is cloned from the base snapshot. With `clone_network_type: static` the address is chosen before the clone, by reading the addresses actually configured on the existing members and taking the first free entry of `static_ip_range`. If every address is taken, the scale-out is skipped and logged, and no clone is created.
 3. **Scale in** — If averages drop below the lower thresholds and the group has more than `min_containers`, the last clone is stopped.
 4. **Grace periods** — Scale-out and scale-in actions are throttled by configurable grace periods.
 
@@ -44,7 +44,7 @@ HORIZONTAL_SCALING_GROUP_1:
 | `max_instances` | Maximum number of containers (clones stop here). |
 | `starting_clone_id` | First container ID for new clones. |
 | `clone_network_type` | `"dhcp"` or `"static"`. |
-| `static_ip_range` | List of IPs for static assignment. Leave `[]` for DHCP. |
+| `static_ip_range` | List of IPs for static assignment. Leave `[]` for DHCP. An entry may carry its own prefix (`10.0.0.5/16`); bare addresses default to `/24`. |
 | `horiz_cpu_upper_threshold` | Group avg CPU % to trigger scale-out. |
 | `horiz_memory_upper_threshold` | Group avg memory % to trigger scale-out. |
 | `horiz_cpu_lower_threshold` | Group avg CPU % to trigger scale-in. |

--- a/lxc_autoscale/lxc_utils.py
+++ b/lxc_autoscale/lxc_utils.py
@@ -887,6 +887,28 @@ def get_container_config(ctid: str) -> Dict[str, Any]:
     return LXC_TIER_ASSOCIATIONS.get(ctid, DEFAULTS)
 
 
+# Matches the address in a net0 line: "name=eth0,bridge=vmbr0,ip=10.0.0.5/24".
+# "ip=dhcp" and "ip=manual" do not match, which is what we want.
+_NET_IPV4_RE = re.compile(r'\bip=(\d{1,3}(?:\.\d{1,3}){3})(?:/\d{1,2})?')
+
+
+async def get_container_ipv4(ctid: str) -> Optional[str]:
+    """Return the static IPv4 configured on net0, without prefix.
+
+    Returns None when the container uses DHCP, has no net0, or cannot be read.
+    """
+    validate_container_id(ctid)
+    output = await run_command(["pct", "config", ctid])
+    if not output:
+        return None
+    for line in output.splitlines():
+        if line.startswith("net0:"):
+            match = _NET_IPV4_RE.search(line)
+            if match:
+                return match.group(1)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Name generation (pure, sync)
 # ---------------------------------------------------------------------------

--- a/lxc_autoscale/scaling_manager.py
+++ b/lxc_autoscale/scaling_manager.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from zoneinfo import ZoneInfo
 
 from config import (
@@ -12,7 +12,7 @@ from config import (
 )
 from lxc_utils import (
     apply_cpu_pinning, backup_container_settings,
-    get_containers, get_cpu_usage, get_memory_usage,
+    get_container_ipv4, get_containers, get_cpu_usage, get_memory_usage,
     get_total_cores, get_total_memory, is_container_running,
     is_ignored, load_backup_settings, log_json_event,
     resolve_cpu_pinning, rollback_container_settings,
@@ -482,6 +482,36 @@ def should_scale_in(metrics, group_config, current_time, last_action_time) -> bo
             metrics['total_containers'] > group_config.get('min_containers', 1))
 
 
+async def _select_static_ip(group_config: Dict[str, Any],
+                            members: List[int]) -> Optional[str]:
+    """Return the first address of static_ip_range not already in use.
+
+    Addresses in use are read from the live net0 of every group member, not
+    inferred from the container ids. Entries may carry a prefix
+    ("10.0.0.5/24"); bare addresses keep the documented /24 default. Returns
+    None when the range is empty or exhausted.
+    """
+    ip_range = group_config.get('static_ip_range', [])
+    if not ip_range:
+        return None
+
+    in_use = set()
+    for ctid in members:
+        try:
+            address = await get_container_ipv4(str(ctid))
+        except ValueError:
+            continue
+        if address:
+            in_use.add(address)
+
+    for entry in ip_range:
+        address = str(entry).split('/')[0]
+        if address in in_use:
+            continue
+        return str(entry) if '/' in str(entry) else f"{address}/24"
+    return None
+
+
 async def scale_out(group_name: str, group_config: Dict[str, Any]) -> None:
     current_instances = sorted(map(int, group_config['lxc_containers']))
     starting_clone_id = group_config['starting_clone_id']
@@ -500,6 +530,23 @@ async def scale_out(group_name: str, group_config: Dict[str, Any]) -> None:
         logger.error("Invalid ID for scale_out in %s: %s", group_name, e)
         return
 
+    # Pick the address before cloning: if the range is exhausted there is no
+    # point creating a clone we would then have to leave misconfigured.
+    net_type = group_config.get('clone_network_type', 'dhcp')
+    static_ip = None
+    if net_type == "static":
+        static_ip = await _select_static_ip(group_config, current_instances)
+        if static_ip is None:
+            logger.error(
+                "No free address in static_ip_range for group %s, skipping scale out",
+                group_name,
+            )
+            await log_scaling_event(
+                group_name, 'scale_out_skipped',
+                {'reason': 'static_ip_range exhausted'}, error=True,
+            )
+            return
+
     unique_snap = generate_unique_snapshot_name("snap")
     if not await run_command(["pct", "snapshot", str(base_snapshot), unique_snap,
                               "--description", "Auto snapshot for scaling"]):
@@ -513,15 +560,11 @@ async def scale_out(group_name: str, group_config: Dict[str, Any]) -> None:
         logger.error("Failed to clone %s", base_snapshot)
         return
 
-    net_type = group_config.get('clone_network_type', 'dhcp')
     if net_type == "dhcp":
         await run_command(["pct", "set", str(new_ctid), "-net0", "name=eth0,bridge=vmbr0,ip=dhcp"])
     elif net_type == "static":
-        available_ips = [ip for ip in group_config.get('static_ip_range', [])
-                         if ip not in current_instances]
-        if available_ips:
-            await run_command(["pct", "set", str(new_ctid), "-net0",
-                               f"name=eth0,bridge=vmbr0,ip={available_ips[0]}/24"])
+        await run_command(["pct", "set", str(new_ctid), "-net0",
+                           f"name=eth0,bridge=vmbr0,ip={static_ip}"])
 
     await run_command(["pct", "start", str(new_ctid)])
     current_instances.append(new_ctid)

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -294,6 +294,79 @@ class TestHorizontalScalingNetwork:
         calls = " ".join(str(c) for c in m_cmd.call_args_list)
         assert "10.0.0.50" in calls
 
+    @patch('scaling_manager.log_json_event', new_callable=AsyncMock)
+    async def test_scale_out_skips_ip_already_in_use(self, m_log):
+        """#70: the address of a live member must not be handed out again."""
+        import scaling_manager as sm
+
+        async def fake_ip(ctid):
+            return '10.0.0.50' if str(ctid) == '100' else None
+
+        with patch('scaling_manager.get_container_ipv4', side_effect=fake_ip), \
+             patch('scaling_manager.run_command', new_callable=AsyncMock,
+                   return_value="OK") as m_cmd:
+            group_config = {
+                'lxc_containers': {'100'},
+                'starting_clone_id': 200,
+                'max_instances': 5,
+                'base_snapshot_name': '100',
+                'clone_network_type': 'static',
+                'static_ip_range': ['10.0.0.50', '10.0.0.51'],
+            }
+            await sm.scale_out("test_grp", group_config)
+
+        calls = " ".join(str(c) for c in m_cmd.call_args_list)
+        assert "10.0.0.51/24" in calls
+        assert "ip=10.0.0.50" not in calls
+
+    @patch('scaling_manager.log_scaling_event', new_callable=AsyncMock)
+    @patch('scaling_manager.log_json_event', new_callable=AsyncMock)
+    async def test_scale_out_aborts_when_range_exhausted(self, m_log, m_event):
+        """#70: no clone at all when every address is taken."""
+        import scaling_manager as sm
+
+        async def fake_ip(ctid):
+            return {'100': '10.0.0.50', '101': '10.0.0.51'}.get(str(ctid))
+
+        with patch('scaling_manager.get_container_ipv4', side_effect=fake_ip), \
+             patch('scaling_manager.run_command', new_callable=AsyncMock,
+                   return_value="OK") as m_cmd:
+            group_config = {
+                'lxc_containers': {'100', '101'},
+                'starting_clone_id': 200,
+                'max_instances': 5,
+                'base_snapshot_name': '100',
+                'clone_network_type': 'static',
+                'static_ip_range': ['10.0.0.50', '10.0.0.51'],
+            }
+            await sm.scale_out("test_grp", group_config)
+
+        # Nothing was created: no snapshot, no clone, no orphan left behind.
+        assert m_cmd.call_count == 0
+
+    @patch('scaling_manager.log_json_event', new_callable=AsyncMock)
+    async def test_scale_out_honours_explicit_prefix(self, m_log):
+        """An entry carrying its own prefix is used verbatim."""
+        import scaling_manager as sm
+
+        async def fake_ip(ctid):
+            return None
+
+        with patch('scaling_manager.get_container_ipv4', side_effect=fake_ip), \
+             patch('scaling_manager.run_command', new_callable=AsyncMock,
+                   return_value="OK") as m_cmd:
+            group_config = {
+                'lxc_containers': {'100'},
+                'starting_clone_id': 200,
+                'max_instances': 5,
+                'base_snapshot_name': '100',
+                'clone_network_type': 'static',
+                'static_ip_range': ['10.0.0.50/16'],
+            }
+            await sm.scale_out("test_grp", group_config)
+
+        assert "10.0.0.50/16" in " ".join(str(c) for c in m_cmd.call_args_list)
+
     @patch('scaling_manager.run_command', new_callable=AsyncMock, return_value="OK")
     @patch('scaling_manager.log_json_event', new_callable=AsyncMock)
     async def test_scale_out_snapshot_fail(self, m_log, m_cmd):

--- a/tests/test_lxc_utils.py
+++ b/tests/test_lxc_utils.py
@@ -330,3 +330,45 @@ class TestPrioritize:
 
     def test_empty_returns_empty(self):
         assert lxc_utils.prioritize_containers({}) == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# #70: reading the address actually configured on a container
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestGetContainerIPv4:
+    def _read(self, config_output):
+        with patch.object(lxc_utils, 'run_command', new_callable=AsyncMock,
+                          return_value=config_output):
+            return asyncio.run(lxc_utils.get_container_ipv4("100"))
+
+    def test_static_address_with_prefix(self):
+        assert self._read(
+            "cores: 2\nnet0: name=eth0,bridge=vmbr0,ip=10.0.0.50/24,gw=10.0.0.1\n"
+        ) == "10.0.0.50"
+
+    def test_static_address_without_prefix(self):
+        assert self._read("net0: name=eth0,bridge=vmbr0,ip=192.168.1.7\n") == "192.168.1.7"
+
+    def test_dhcp_returns_none(self):
+        assert self._read("net0: name=eth0,bridge=vmbr0,ip=dhcp\n") is None
+
+    def test_manual_returns_none(self):
+        assert self._read("net0: name=eth0,bridge=vmbr0,ip=manual\n") is None
+
+    def test_no_net0_returns_none(self):
+        assert self._read("cores: 2\nmemory: 512\n") is None
+
+    def test_unreadable_config_returns_none(self):
+        assert self._read(None) is None
+
+    def test_ignores_addresses_on_other_interfaces(self):
+        # Only net0 is managed by horizontal scaling.
+        assert self._read(
+            "net1: name=eth1,bridge=vmbr1,ip=172.16.0.9/24\n"
+            "net0: name=eth0,bridge=vmbr0,ip=dhcp\n"
+        ) is None
+
+    def test_rejects_invalid_ctid(self):
+        with pytest.raises(ValueError):
+            asyncio.run(lxc_utils.get_container_ipv4("100; rm -rf /"))


### PR DESCRIPTION
Fixes #70.

## The bug

```python
available_ips = [ip for ip in group_config.get("static_ip_range", [])
                 if ip not in current_instances]
```

`current_instances` is a list of integer container ids, `static_ip_range` a list of IP strings. The membership test is always false, so the filter never excludes anything and `available_ips[0]` is always the first entry of the range. Every clone after the first gets a duplicate address.

## The fix

Addresses in use are read from the live `net0` of each group member, through a new `get_container_ipv4` helper. It ignores `ip=dhcp` and `ip=manual`, and only looks at `net0`, the interface horizontal scaling actually manages.

The selection also moves **before** the clone. The old order had a second failure mode: when the range was exhausted the code fell through the `if available_ips:` and still ran `pct start`, so the clone came up carrying the source container's network configuration, which is another duplicate address. Now an exhausted range skips the scale-out, logs the reason as a structured event, and creates nothing at all.

While here, an entry may carry its own prefix (`10.0.0.5/16`); bare addresses keep the documented `/24` default. The hardcoded `vmbr0` bridge is deliberately left alone: it belongs to the ASG work, not to this fix.

## Tests

10 new tests. Seven cover the parser (prefix, no prefix, dhcp, manual, no net0, unreadable config, an address on `net1` that must be ignored, invalid ctid). Three cover the behaviour that was broken: the address of a live member is not handed out again, an exhausted range creates nothing, and an explicit prefix is used verbatim.

357 passed. The same 5 failures occur on `main` in a full-suite run and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)