### PR TITLE
fix: honour min_instances instead of silently ignoring it (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **`min_instances` was documented but silently ignored** ([#71](https://github.com/fabriziosalmi/proxmox-lxc-autoscale/issues/71)): the guide documented `min_instances` and used it in its example, while the code read `min_containers` and the model accepted unknown keys, so a group configured per the documentation had a floor of 1 instead of the value set. `min_instances` is now canonical, matching `max_instances`; `min_containers` keeps working as a deprecated alias and logs a warning; the two disagreeing is a config error rather than a coin flip. `min_instances` is also validated against `max_instances`. Unknown keys in a horizontal group are now reported at load instead of being swallowed, which is how the original mismatch stayed invisible.
 - **Horizontal scaling handed the same static IP to every clone** ([#70](https://github.com/fabriziosalmi/proxmox-lxc-autoscale/issues/70)): the filter that was meant to skip addresses already in use compared IP strings against the list of integer container ids, so it never excluded anything and every clone received `static_ip_range[0]`. Addresses in use are now read from the live `net0` of each group member. The address is also chosen before the clone rather than after, so an exhausted range skips the scale-out instead of leaving behind a clone that could not be configured. Entries in `static_ip_range` may now carry their own prefix; bare addresses keep the documented `/24` default.
 
 ### Security

--- a/docs/guide/horizontal-scaling.md
+++ b/docs/guide/horizontal-scaling.md
@@ -32,7 +32,7 @@ HORIZONTAL_SCALING_GROUP_1:
 
 1. **Metrics** — Average CPU and memory usage are calculated across all containers in the group.
 2. **Scale out** — If averages exceed the upper thresholds, a new container is cloned from the base snapshot. With `clone_network_type: static` the address is chosen before the clone, by reading the addresses actually configured on the existing members and taking the first free entry of `static_ip_range`. If every address is taken, the scale-out is skipped and logged, and no clone is created.
-3. **Scale in** — If averages drop below the lower thresholds and the group has more than `min_containers`, the last clone is stopped.
+3. **Scale in** — If averages drop below the lower thresholds and the group has more than `min_instances`, the last clone is stopped.
 4. **Grace periods** — Scale-out and scale-in actions are throttled by configurable grace periods.
 
 ## Parameters
@@ -40,8 +40,9 @@ HORIZONTAL_SCALING_GROUP_1:
 | Parameter | Description |
 |-----------|-------------|
 | `base_snapshot_name` | Container ID to use as the clone source. |
-| `min_instances` | Minimum number of containers in the group. |
+| `min_instances` | Minimum number of containers in the group. Never scales below this. |
 | `max_instances` | Maximum number of containers (clones stop here). |
+| `min_containers` | Deprecated alias for `min_instances`. Still honoured, logs a warning at startup. |
 | `starting_clone_id` | First container ID for new clones. |
 | `clone_network_type` | `"dhcp"` or `"static"`. |
 | `static_ip_range` | List of IPs for static assignment. Leave `[]` for DHCP. An entry may carry its own prefix (`10.0.0.5/16`); bare addresses default to `/24`. |

--- a/lxc_autoscale/config.py
+++ b/lxc_autoscale/config.py
@@ -210,7 +210,11 @@ class HorizontalScalingGroup(BaseModel):
     horiz_cpu_lower_threshold: float = 20
     horiz_memory_upper_threshold: float = 80
     horiz_memory_lower_threshold: float = 20
-    min_containers: int = 1
+    # min_instances is canonical: it matches max_instances and the documentation.
+    # min_containers is the name the code originally read and is kept as a
+    # deprecated alias. Both end up holding the same resolved value.
+    min_instances: Optional[int] = None
+    min_containers: Optional[int] = None
     max_instances: int = 5
     starting_clone_id: int = 200
     base_snapshot_name: str = ""
@@ -231,6 +235,37 @@ class HorizontalScalingGroup(BaseModel):
             raise ValueError(
                 f"Invalid base_snapshot_name: {self.base_snapshot_name!r} (must be numeric)"
             )
+        return self
+
+    @model_validator(mode="after")
+    def resolve_min_instances(self) -> "HorizontalScalingGroup":
+        """Reconcile min_instances with its deprecated alias min_containers."""
+        if (self.min_instances is not None and self.min_containers is not None
+                and self.min_instances != self.min_containers):
+            raise ValueError(
+                f"min_instances ({self.min_instances}) and min_containers "
+                f"({self.min_containers}) disagree. Keep only min_instances."
+            )
+        if self.min_instances is None and self.min_containers is not None:
+            logging.warning(
+                "min_containers is deprecated, use min_instances instead "
+                "(currently %d)", self.min_containers,
+            )
+        resolved = self.min_instances
+        if resolved is None:
+            resolved = self.min_containers
+        if resolved is None:
+            resolved = 1
+        if resolved < 1:
+            raise ValueError(f"min_instances must be >= 1, got {resolved}")
+        if resolved > self.max_instances:
+            raise ValueError(
+                f"min_instances ({resolved}) must be <= max_instances "
+                f"({self.max_instances})"
+            )
+        # Keep both names holding the resolved value so any reader agrees.
+        self.min_instances = resolved
+        self.min_containers = resolved
         return self
 
 
@@ -344,7 +379,15 @@ def load_config(path: str = CONFIG_FILE) -> "AppConfig":
             lxc = group_raw.get("lxc_containers")
             if isinstance(lxc, list):
                 group_raw["lxc_containers"] = set(map(str, lxc))
-                horiz_groups[section] = HorizontalScalingGroup(**group_raw)
+            # The model allows extra keys for backward compatibility, which
+            # means a typo would otherwise be accepted and ignored in silence.
+            unknown = set(group_raw) - set(HorizontalScalingGroup.model_fields)
+            if unknown:
+                logging.warning(
+                    "%s: unknown key(s) %s, ignored. Check for a typo.",
+                    section, ", ".join(sorted(unknown)),
+                )
+            horiz_groups[section] = HorizontalScalingGroup(**group_raw)
 
     return AppConfig(
         defaults=defaults,

--- a/lxc_autoscale/scaling_manager.py
+++ b/lxc_autoscale/scaling_manager.py
@@ -474,12 +474,24 @@ def should_scale_out(metrics, group_config, current_time, last_action_time) -> b
             metrics['avg_mem_usage'] > group_config['horiz_memory_upper_threshold'])
 
 
+def group_min_instances(group_config: Dict[str, Any]) -> int:
+    """Minimum group size, accepting the deprecated min_containers alias.
+
+    Config loading resolves the two names, but group dicts also reach this
+    module from tests and from callers that build them by hand.
+    """
+    value = group_config.get('min_instances')
+    if value is None:
+        value = group_config.get('min_containers')
+    return 1 if value is None else int(value)
+
+
 def should_scale_in(metrics, group_config, current_time, last_action_time) -> bool:
     if current_time - last_action_time < timedelta(seconds=group_config.get('scale_in_grace_period', 600)):
         return False
     return (metrics['avg_cpu_usage'] < group_config['horiz_cpu_lower_threshold'] and
             metrics['avg_mem_usage'] < group_config['horiz_memory_lower_threshold'] and
-            metrics['total_containers'] > group_config.get('min_containers', 1))
+            metrics['total_containers'] > group_min_instances(group_config))
 
 
 async def _select_static_ip(group_config: Dict[str, Any],
@@ -576,7 +588,7 @@ async def scale_out(group_name: str, group_config: Dict[str, Any]) -> None:
 
 async def scale_in(group_name: str, group_config: Dict[str, Any]) -> None:
     current_instances = sorted(map(int, group_config['lxc_containers']))
-    if len(current_instances) <= group_config.get('min_containers', 1):
+    if len(current_instances) <= group_min_instances(group_config):
         return
     remove_ctid = str(current_instances[-1])
     try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,9 @@ import yaml
 # Add lxc_autoscale to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lxc_autoscale'))
 
-from config import DefaultsConfig, TierConfig, SSHConfig, load_config
+from config import (
+    DefaultsConfig, HorizontalScalingGroup, TierConfig, SSHConfig, load_config,
+)
 
 
 class TestDefaultsConfig:
@@ -183,3 +185,75 @@ class TestLoadConfig:
         assert isinstance(DEFAULTS, dict)
         assert isinstance(IGNORE_LXC, set)
         assert isinstance(LOG_FILE, str)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# #71: min_instances was documented but silently ignored
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestHorizontalGroupMinInstances:
+    def test_min_instances_is_honoured(self):
+        group = HorizontalScalingGroup(min_instances=3)
+        assert group.min_instances == 3
+        assert group.min_containers == 3  # alias kept in sync
+
+    def test_deprecated_alias_still_works(self, caplog):
+        group = HorizontalScalingGroup(min_containers=2)
+        assert group.min_instances == 2
+        assert "min_containers is deprecated" in caplog.text
+
+    def test_default_is_one(self):
+        group = HorizontalScalingGroup()
+        assert group.min_instances == 1
+
+    def test_conflicting_values_are_rejected(self):
+        with pytest.raises(ValueError, match="disagree"):
+            HorizontalScalingGroup(min_instances=2, min_containers=4)
+
+    def test_matching_values_are_accepted(self):
+        assert HorizontalScalingGroup(min_instances=2, min_containers=2).min_instances == 2
+
+    def test_min_above_max_is_rejected(self):
+        with pytest.raises(ValueError, match="must be <= max_instances"):
+            HorizontalScalingGroup(min_instances=9, max_instances=5)
+
+    def test_zero_is_rejected(self):
+        with pytest.raises(ValueError, match="must be >= 1"):
+            HorizontalScalingGroup(min_instances=0)
+
+    def test_documented_example_loads_with_the_documented_meaning(self, caplog):
+        """The example in docs/guide/horizontal-scaling.md must mean what it says."""
+        raw = {
+            "HORIZONTAL_SCALING_GROUP_1": {
+                "base_snapshot_name": "101",
+                "min_instances": 2,
+                "max_instances": 5,
+                "starting_clone_id": 99000,
+                "lxc_containers": ["101"],
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            yaml.safe_dump(raw, f)
+            path = f.name
+        try:
+            app_cfg = load_config(path)
+            group = app_cfg.horizontal_scaling_groups["HORIZONTAL_SCALING_GROUP_1"]
+            assert group.min_instances == 2
+        finally:
+            os.unlink(path)
+
+    def test_unknown_key_is_reported(self, caplog):
+        raw = {
+            "HORIZONTAL_SCALING_GROUP_1": {
+                "lxc_containers": ["101"],
+                "min_instancess": 2,  # typo
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            yaml.safe_dump(raw, f)
+            path = f.name
+        try:
+            load_config(path)
+            assert "min_instancess" in caplog.text
+        finally:
+            os.unlink(path)

--- a/tests/test_scaling_manager.py
+++ b/tests/test_scaling_manager.py
@@ -117,6 +117,29 @@ class TestScaleInDecision:
             now, now - timedelta(seconds=1000)
         ) is False
 
+    def test_min_instances_stops_the_scale_in(self):
+        """#71: the documented key must actually hold the floor."""
+        now = datetime.now()
+        assert should_scale_in(
+            {'avg_cpu_usage': 5, 'avg_mem_usage': 5, 'total_containers': 2},
+            {'horiz_cpu_lower_threshold': 20, 'horiz_memory_lower_threshold': 20,
+             'scale_in_grace_period': 600, 'min_instances': 2},
+            now, now - timedelta(seconds=1000)
+        ) is False
+
+
+class TestGroupMinInstances:
+    """#71: resolution of min_instances and its deprecated alias."""
+
+    def test_prefers_min_instances(self):
+        assert scaling_manager.group_min_instances({'min_instances': 3, 'min_containers': 9}) == 3
+
+    def test_falls_back_to_alias(self):
+        assert scaling_manager.group_min_instances({'min_containers': 4}) == 4
+
+    def test_defaults_to_one(self):
+        assert scaling_manager.group_min_instances({}) == 1
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Async scaling functions


### PR DESCRIPTION
Fixes #71.

## The bug

`docs/guide/horizontal-scaling.md` documents `min_instances` and uses it in its example. The code read `min_containers`, and `HorizontalScalingGroup` sets `extra="allow"`, so the key was accepted and discarded. A group configured exactly as documented had a floor of one container, with nothing in the log to suggest it.

The documentation was also inconsistent with itself: the example and the parameter table say `min_instances`, the description of scale-in says `min_containers`.

## The fix

`min_instances` becomes canonical, which matches `max_instances` and the documentation. `min_containers` keeps working as a deprecated alias and logs a warning at load, so no existing configuration breaks.

Two things that were never checked are now checked:

- Setting both keys to different values is a config error instead of a silent coin flip.
- `min_instances` is validated against `max_instances`, and against being below 1.

**Unknown keys in a horizontal group are now reported at load.** The model still accepts them for backward compatibility, but a typo no longer disappears in silence. This is exactly how the original mismatch survived, so fixing the symptom without this would leave the mechanism in place.

While here, group registration no longer sits inside the `isinstance(lxc, list)` branch. A group written without `lxc_containers` used to vanish from the configuration entirely; it is now loaded and reported as empty.

## Tests

13 new tests. Nine on the model (canonical key, deprecated alias with its warning, default, conflict, matching duplicates, min above max, zero, the documented example loading with the documented meaning, unknown key reported) and four on the consumer side (`should_scale_in` honouring `min_instances`, plus the resolution helper).

370 passed. The same 5 failures occur on `main` in a full-suite run and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)