### PR TITLE
ci: run the test matrix on pull requests, not only on push

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,14 @@
 name: Pylint
-on: [push]
+# push covers the maintainer's own branches; pull_request is what makes the
+# suite run for a contribution from a fork, which "on: [push]" never did.
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
`pylint.yml` triggered on `push` only. A pull request from a fork pushes to the fork, so nothing ran here: #76, an external contribution that rewrites the code writing to `/etc/pve/lxc/*.conf` as root, reports `no checks reported` on all four Python versions.

The gap stayed invisible because my own branches are pushed to this repository, so my PRs always showed checks. It only ever affected outside contributions, which is precisely when the matrix earns its keep.

`push` is now scoped to `main`, so a branch pushed here and then opened as a PR does not run the matrix twice, and a concurrency group cancels superseded runs.

Found while reviewing #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)