### PR TITLE
fix(pinning): write the pin where the container reads it

### DIFF
--- a/lxc_autoscale/lxc_utils.py
+++ b/lxc_autoscale/lxc_utils.py
@@ -62,6 +62,61 @@ async def run_command(cmd: Union[str, List[str]], timeout: int = 30) -> Optional
     return await run_local_command(cmd, timeout)
 
 
+async def run_command_with_input(
+    cmd: Union[str, List[str]], data: str, timeout: int = 30,
+) -> bool:
+    """
+    Run a command where the container config is running, feeding it `data`.
+
+    Mirrors run_command: local when the daemon runs on the node, over SSH when
+    use_remote_proxmox is set. The remote branch of apply_cpu_pinning used to
+    build its content correctly and then hand it to a local subprocess, so the
+    node it was talking to never received the write.
+
+    Args:
+        cmd: The command to run.
+        data: What to write to its standard input.
+        timeout: Seconds to wait.
+
+    Returns:
+        True when the command exited zero.
+    """
+    cfg = get_app_config()
+    if cfg.defaults.use_remote_proxmox:
+        from ssh import AsyncSSHPool
+        global _ssh_pool
+        if _ssh_pool is None:
+            _ssh_pool = AsyncSSHPool(cfg.defaults.get_ssh_config())
+        return await _ssh_pool.run_command_with_input(cmd, data, timeout)
+    return await run_local_command_with_input(cmd, data, timeout)
+
+
+async def run_local_command_with_input(
+    cmd: Union[str, List[str]], data: str, timeout: int = 30,
+) -> bool:
+    """Run a local command, feeding it `data` on stdin."""
+    if isinstance(cmd, str):
+        import shlex
+        cmd = shlex.split(cmd)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(input=data.encode()), timeout=timeout)
+        if proc.returncode == 0:
+            return True
+        logger.error("Command failed (rc=%d): %s — %s",
+                     proc.returncode, cmd, stderr.decode('utf-8').strip())
+    except asyncio.TimeoutError:
+        logger.error("Command timed out after %ds: %s", timeout, cmd)
+        proc.kill()
+        await proc.wait()
+    except OSError as e:
+        logger.error("OS error executing %s: %s", cmd, e)
+    return False
+
+
 async def run_local_command(cmd: Union[str, List[str]], timeout: int = 30) -> Optional[str]:
     if isinstance(cmd, str):
         import shlex
@@ -384,6 +439,105 @@ async def resolve_cpu_pinning(pinning_config: str) -> Optional[str]:
 _applied_pinning = _state.applied_pinning
 
 
+_CPUSET_KEY = "lxc.cgroup2.cpuset.cpus:"
+
+# A pct container config holds the live configuration first, then one
+# `[snapshotname]` section per snapshot, each a full copy of the config at the
+# time it was taken (pct(1), "Snapshots"). Only the part before the first
+# section header applies to the running container.
+_SECTION_HEADER_RE = re.compile(r"^\[")
+
+
+def _split_live_section(content: str) -> Tuple[List[str], List[str]]:
+    """
+    Splits a container config into its live lines and everything after them.
+
+    Args:
+        content: The whole config file.
+
+    Returns:
+        (live_lines, rest_lines), where rest_lines starts at the first
+        `[snapshot]` header and is returned untouched.
+    """
+    lines = content.splitlines(True)
+    for index, line in enumerate(lines):
+        if _SECTION_HEADER_RE.match(line):
+            return lines[:index], lines[index:]
+    return lines, []
+
+
+def _set_cpuset_line(content: str, cpu_range: str) -> Tuple[str, bool]:
+    """
+    Sets the cpuset key in the live section of a container config.
+
+    Writing to the file as if it were flat put the pin inside the last snapshot
+    section, where it has no effect on the running container, and a cpuset line
+    found in a snapshot was taken as proof the live section already had one.
+
+    Args:
+        content: The whole config file.
+        cpu_range: The value for `lxc.cgroup2.cpuset.cpus`.
+
+    Returns:
+        (new_content, changed). `changed` is False when the live section
+        already carries exactly this pin, so the caller can skip the write.
+    """
+    target = f"{_CPUSET_KEY} {cpu_range}"
+    live, rest = _split_live_section(content)
+
+    for index, line in enumerate(live):
+        stripped = line.strip()
+        if stripped == target:
+            return content, False
+        if stripped.startswith(_CPUSET_KEY):
+            live[index] = target + "\n"
+            return "".join(live) + "".join(rest), True
+
+    # Append at the end of the live section, not at the end of the file.
+    if live and not live[-1].endswith("\n"):
+        live[-1] += "\n"
+    live.append(target + "\n")
+    return "".join(live) + "".join(rest), True
+
+
+def _container_conf_path(ctid: str) -> str:
+    """The documented path of a container config, before symlink resolution."""
+    return f"/etc/pve/lxc/{ctid}.conf"
+
+
+def _is_expected_conf_path(real_path: str, ctid: str) -> bool:
+    """
+    Checks that a resolved config path is one pmxcfs is expected to produce.
+
+    `/etc/pve/lxc` is documented as a symbolic link to
+    `nodes/<LOCAL_HOST_NAME>/lxc/` (pmxcfs, "Symbolic links"), so on every node
+    the realpath of a container config is under `/etc/pve/nodes/<node>/lxc/`.
+    Requiring the resolved path to still start with `/etc/pve/lxc/` therefore
+    rejected the only path that exists, and every local write was refused as a
+    symlink attack.
+
+    Args:
+        real_path: The path after `os.path.realpath`.
+        ctid: The container ID the path is supposed to belong to.
+
+    Returns:
+        True when the path is `/etc/pve/lxc/<ctid>.conf` or
+        `/etc/pve/nodes/<node>/lxc/<ctid>.conf`.
+    """
+    expected_name = f"{ctid}.conf"
+    if os.path.basename(real_path) != expected_name:
+        return False
+    parent = os.path.dirname(real_path)
+    if parent == "/etc/pve/lxc":
+        return True
+    prefix, _, node_dir = parent.rpartition("/lxc")
+    if node_dir or not prefix.startswith("/etc/pve/nodes/"):
+        return False
+    # /etc/pve/nodes/<node>/lxc — exactly one path element for the node name.
+    node = prefix[len("/etc/pve/nodes/"):]
+    return bool(node) and "/" not in node
+
+
 async def apply_cpu_pinning(ctid: str, cpu_range: str) -> bool:
     """Apply CPU core pinning only if it differs from last applied state."""
     validate_container_id(ctid)
@@ -396,60 +550,55 @@ async def apply_cpu_pinning(ctid: str, cpu_range: str) -> bool:
         logger.debug("Container %s: pinning unchanged (%s), skipping", ctid, cpu_range)
         return True
 
-    conf_path = f"/etc/pve/lxc/{ctid}.conf"
-    target_line = f"lxc.cgroup2.cpuset.cpus: {cpu_range}"
+    conf_path = _container_conf_path(ctid)
 
     cfg = get_app_config()
     if cfg.defaults.use_remote_proxmox:
-        # Remote: read file, build new content in Python, write back via tee.
-        # Never pass user-controlled data through sed or sh -c.
+        # Remote: read the file, rewrite it in Python, write it back through
+        # tee's stdin. Never pass user-controlled data through sed or sh -c.
         current = await run_command(["cat", conf_path])
         if current is None:
             logger.error("Cannot read config file %s", conf_path)
             return False
-        lines = current.splitlines(True)
-        found = False
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-            if stripped == target_line:
-                _applied_pinning[ctid] = cpu_range
-                return True
-            if stripped.startswith('lxc.cgroup2.cpuset.cpus:'):
-                lines[i] = target_line + '\n'
-                found = True
-        if not found:
-            lines.append(target_line + '\n')
-        new_content = ''.join(lines)
-        # Write back atomically via tee (stdin, no shell interpolation)
-        proc = await asyncio.create_subprocess_exec(
-            "tee", conf_path,
-            stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.DEVNULL,
-        )
-        await proc.communicate(input=new_content.encode())
-        if proc.returncode != 0:
+
+        # run_command strips its output, so the trailing newline of the file is
+        # gone by the time it arrives here. Appending to it without restoring
+        # one produced `swap: 512lxc.cgroup2.cpuset.cpus: 0-3`, corrupting the
+        # last key of the live section.
+        if current and not current.endswith("\n"):
+            current += "\n"
+
+        new_content, changed = _set_cpuset_line(current, cpu_range)
+        if not changed:
+            _applied_pinning[ctid] = cpu_range
+            return True
+
+        # The write has to happen on the node that holds the container. The
+        # previous version built the content correctly and then handed it to a
+        # local `tee`, so the remote config was never touched, and on a daemon
+        # host that happens to have /etc/pve/lxc the remote container's config
+        # was written into the local node's directory.
+        if not await run_command_with_input(["tee", conf_path], new_content):
             logger.error("Failed to set CPU pinning for container %s", ctid)
             return False
     else:
         # Local: native Python file I/O — no shell, no injection risk
         try:
             real_conf = os.path.realpath(conf_path)
-            if not real_conf.startswith('/etc/pve/lxc/'):
-                logger.error("Symlink attack on config path: %s -> %s", conf_path, real_conf)
+            if not _is_expected_conf_path(real_conf, ctid):
+                logger.error("Unexpected config path for container %s: %s -> %s",
+                             ctid, conf_path, real_conf)
                 return False
             with open(real_conf, 'r', encoding='utf-8') as f:
-                lines = f.readlines()
-            found = False
-            for i, line in enumerate(lines):
-                if line.strip() == target_line:
-                    _applied_pinning[ctid] = cpu_range
-                    return True
-                if line.startswith('lxc.cgroup2.cpuset.cpus:'):
-                    lines[i] = target_line + '\n'
-                    found = True
-            if not found:
-                lines.append(target_line + '\n')
+                current = f.read()
+
+            new_content, changed = _set_cpuset_line(current, cpu_range)
+            if not changed:
+                _applied_pinning[ctid] = cpu_range
+                return True
+
             with open(real_conf, 'w', encoding='utf-8') as f:
-                f.writelines(lines)
+                f.write(new_content)
         except OSError as e:
             logger.error("Failed to set CPU pinning for container %s: %s", ctid, e)
             return False

--- a/lxc_autoscale/ssh.py
+++ b/lxc_autoscale/ssh.py
@@ -103,6 +103,13 @@ class AsyncSSHPool:
             stdin.write(data)
             stdin.flush()
             stdin.channel.shutdown_write()
+            # stdout has to be drained before waiting for the exit status.
+            # `tee` echoes its input, so on a config large enough to fill the
+            # channel window the remote command blocks writing, never exits,
+            # and recv_exit_status() waits for it forever. Reading stderr first
+            # does not help: it returns at EOF, which only arrives when the
+            # command exits.
+            stdout.read()
             err = stderr.read().decode("utf-8").strip()
             exit_code = stdout.channel.recv_exit_status()
             self._release(client)

--- a/lxc_autoscale/ssh.py
+++ b/lxc_autoscale/ssh.py
@@ -71,6 +71,53 @@ class AsyncSSHPool:
             cmd = shlex.join(cmd)
         return await asyncio.to_thread(self._run_sync, cmd, timeout)
 
+    async def run_command_with_input(
+        self, cmd: Union[str, List[str]], data: str, timeout: int = 30,
+    ) -> bool:
+        """
+        Execute a command on the remote host, feeding it `data` on stdin.
+
+        Writing a file remotely needs the content to reach the far side without
+        going through the shell: a here-document or an echo would interpolate
+        it. This sends it down the channel's stdin instead, so nothing in the
+        payload is ever parsed as a command.
+
+        Args:
+            cmd: The command to run.
+            data: What to write to its standard input.
+            timeout: Seconds to wait.
+
+        Returns:
+            True when the command exited zero.
+        """
+        if isinstance(cmd, list):
+            cmd = shlex.join(cmd)
+        return await asyncio.to_thread(self._run_sync_with_input, cmd, data, timeout)
+
+    def _run_sync_with_input(self, cmd: str, data: str, timeout: int) -> bool:
+        """Synchronous stdin-fed SSH execution (called in a thread)."""
+        logger.debug("SSH command with input: %s (%d bytes)", cmd, len(data))
+        client = self._acquire()
+        try:
+            stdin, stdout, stderr = client.exec_command(cmd, timeout=timeout)
+            stdin.write(data)
+            stdin.flush()
+            stdin.channel.shutdown_write()
+            err = stderr.read().decode("utf-8").strip()
+            exit_code = stdout.channel.recv_exit_status()
+            self._release(client)
+            if exit_code != 0:
+                logger.error("SSH command failed (rc=%d): %s — %s", exit_code, cmd, err)
+                return False
+            return True
+        except paramiko.SSHException as e:
+            logger.error("SSH execution failed: %s", e)
+            self._discard(client)
+        except OSError as e:
+            logger.error("SSH connection error: %s", e)
+            self._discard(client)
+        return False
+
     def _run_sync(self, cmd: str, timeout: int) -> Optional[str]:
         """Synchronous SSH command execution (called in a thread)."""
         logger.debug("SSH command: %s", cmd)

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -172,25 +172,34 @@ class TestMemoryFallback:
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestCpuPinningRemote:
-    @patch('lxc_utils.asyncio.create_subprocess_exec')
+    @patch('lxc_utils.run_command_with_input', new_callable=AsyncMock, return_value=True)
     @patch('lxc_utils.run_command', new_callable=AsyncMock)
-    async def test_remote_append_via_tee(self, m_cmd, m_exec):
+    async def test_remote_append_via_tee(self, m_cmd, m_write):
+        """
+        The write has to go through the channel that reaches the node.
+
+        This previously mocked asyncio.create_subprocess_exec and passed, which
+        is what hid the defect: the remote branch built the right content and
+        then handed it to a *local* subprocess, so the node was never written.
+        """
         import lxc_utils
         lxc_utils._applied_pinning.clear()
         cfg_mock = MagicMock()
         cfg_mock.defaults.use_remote_proxmox = True
 
-        m_cmd.return_value = "arch: amd64\nmemory: 2048\n"  # no existing pinning
-
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"", b"")
-        mock_proc.returncode = 0
-        m_exec.return_value = mock_proc
+        m_cmd.return_value = "arch: amd64\nmemory: 2048"  # run_command strips
 
         with patch('lxc_utils.get_app_config', return_value=cfg_mock):
             result = await lxc_utils.apply_cpu_pinning("100", "0-3")
             assert result is True
             assert lxc_utils._applied_pinning["100"] == "0-3"
+
+        m_write.assert_awaited_once()
+        cmd, written = m_write.await_args.args[0], m_write.await_args.args[1]
+        assert cmd == ["tee", "/etc/pve/lxc/100.conf"]
+        # The newline run_command stripped has to come back, or the appended
+        # line fuses onto the last key: `memory: 2048lxc.cgroup2...`.
+        assert written == "arch: amd64\nmemory: 2048\nlxc.cgroup2.cpuset.cpus: 0-3\n"
 
     @patch('lxc_utils.run_command', new_callable=AsyncMock)
     async def test_remote_already_set(self, m_cmd):

--- a/tests/test_cpu_pinning_write.py
+++ b/tests/test_cpu_pinning_write.py
@@ -219,3 +219,69 @@ class TestRemoteWrite:
              patch("lxc_utils.run_command_with_input", new_callable=AsyncMock) as write:
             assert await lxc_utils.apply_cpu_pinning("100", "0-3") is True
         write.assert_not_awaited()
+
+
+class TestRemoteStdinChannel:
+    """
+    AsyncSSHPool._run_sync_with_input.
+
+    `tee` echoes its input to stdout. If stdout is not drained, a config large
+    enough to fill the SSH channel window blocks the remote command, which then
+    never exits, so recv_exit_status waits for it forever. Reading stderr first
+    does not help: it returns at EOF, and EOF arrives when the command exits.
+    """
+
+    def _pool_with_mock_client(self, client):
+        from ssh import AsyncSSHPool
+        pool = AsyncSSHPool.__new__(AsyncSSHPool)
+        pool._acquire = lambda: client
+        pool._release = lambda c: None
+        pool._discard = lambda c: None
+        return pool
+
+    def test_stdout_is_drained_before_waiting_for_the_exit_status(self):
+        order = []
+        stdout = MagicMock()
+        stdout.read.side_effect = lambda: order.append("stdout") or b""
+        stdout.channel.recv_exit_status.side_effect = lambda: order.append("wait") or 0
+        stderr = MagicMock()
+        stderr.read.return_value = b""
+        stdin = MagicMock()
+        client = MagicMock()
+        client.exec_command.return_value = (stdin, stdout, stderr)
+
+        pool = self._pool_with_mock_client(client)
+        assert pool._run_sync_with_input("tee /etc/pve/lxc/100.conf", "arch: amd64\n", 30) is True
+
+        assert order.index("stdout") < order.index("wait"), (
+            "stdout must be read before recv_exit_status, or a payload that "
+            "fills the channel window deadlocks the write"
+        )
+
+    def test_stdin_is_closed_so_the_command_can_finish(self):
+        stdout = MagicMock()
+        stdout.read.return_value = b""
+        stdout.channel.recv_exit_status.return_value = 0
+        stderr = MagicMock()
+        stderr.read.return_value = b""
+        stdin = MagicMock()
+        client = MagicMock()
+        client.exec_command.return_value = (stdin, stdout, stderr)
+
+        pool = self._pool_with_mock_client(client)
+        pool._run_sync_with_input("tee x", "data", 30)
+
+        stdin.write.assert_called_once_with("data")
+        stdin.channel.shutdown_write.assert_called_once()
+
+    def test_a_nonzero_exit_is_a_failure(self):
+        stdout = MagicMock()
+        stdout.read.return_value = b""
+        stdout.channel.recv_exit_status.return_value = 1
+        stderr = MagicMock()
+        stderr.read.return_value = b"permission denied"
+        client = MagicMock()
+        client.exec_command.return_value = (MagicMock(), stdout, stderr)
+
+        pool = self._pool_with_mock_client(client)
+        assert pool._run_sync_with_input("tee x", "data", 30) is False

--- a/tests/test_cpu_pinning_write.py
+++ b/tests/test_cpu_pinning_write.py
@@ -1,0 +1,221 @@
+"""
+Writing a CPU pin into a container config.
+
+Four defects meant no pin was ever written, on either path, and none of them
+produced a visible error beyond one line at ERROR on the local path:
+
+1. the symlink guard rejected the path pmxcfs actually produces
+2. the remote branch wrote through a local subprocess, so the node never saw it
+3. the remote read lost its trailing newline and fused the appended line onto
+   the last key
+4. the pin was appended after the snapshot sections, where it does nothing, and
+   a cpuset line inside a snapshot was read as proof the live section had one
+
+Each is covered below against the shape of a real config: pct stores every
+snapshot as a `[name]` section holding a full copy of the configuration.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lxc_autoscale"))
+
+import lxc_utils  # noqa: E402
+
+
+# A config with one snapshot, which is the case the flat rewrite got wrong.
+CONFIG_WITH_SNAPSHOT = """arch: amd64
+hostname: web01
+memory: 2048
+swap: 512
+
+[before-upgrade]
+arch: amd64
+hostname: web01
+lxc.cgroup2.cpuset.cpus: 8-11
+memory: 1024
+swap: 512
+"""
+
+
+class TestLiveSectionRewrite:
+    """_set_cpuset_line: the pure part, testable without a filesystem."""
+
+    def test_appends_inside_the_live_section(self):
+        new, changed = lxc_utils._set_cpuset_line(CONFIG_WITH_SNAPSHOT, "0-3")
+        assert changed is True
+        live = new.split("[before-upgrade]")[0]
+        assert "lxc.cgroup2.cpuset.cpus: 0-3" in live, (
+            "the pin has to land in the live section; appended after the "
+            "snapshot header it has no effect on the running container"
+        )
+
+    def test_leaves_the_snapshot_untouched(self):
+        new, _ = lxc_utils._set_cpuset_line(CONFIG_WITH_SNAPSHOT, "0-3")
+        snapshot = new.split("[before-upgrade]")[1]
+        assert "lxc.cgroup2.cpuset.cpus: 8-11" in snapshot, (
+            "a snapshot is a record of what the config was; rewriting it "
+            "would falsify history"
+        )
+
+    def test_a_pin_in_a_snapshot_is_not_mistaken_for_the_live_one(self):
+        """
+        The old code scanned the file flat, so the snapshot's cpuset line set
+        found=True and the live section never got one.
+        """
+        new, changed = lxc_utils._set_cpuset_line(CONFIG_WITH_SNAPSHOT, "8-11")
+        assert changed is True
+        live = new.split("[before-upgrade]")[0]
+        assert "lxc.cgroup2.cpuset.cpus: 8-11" in live
+
+    def test_replaces_an_existing_live_pin(self):
+        content = "arch: amd64\nlxc.cgroup2.cpuset.cpus: 0-1\nmemory: 2048\n"
+        new, changed = lxc_utils._set_cpuset_line(content, "4-7")
+        assert changed is True
+        assert "lxc.cgroup2.cpuset.cpus: 4-7" in new
+        assert "0-1" not in new
+
+    def test_reports_no_change_when_already_correct(self):
+        content = "arch: amd64\nlxc.cgroup2.cpuset.cpus: 0-3\n"
+        new, changed = lxc_utils._set_cpuset_line(content, "0-3")
+        assert changed is False
+        assert new == content
+
+    def test_restores_a_missing_trailing_newline(self):
+        """run_command strips its output, so the content arrives without one."""
+        new, changed = lxc_utils._set_cpuset_line("arch: amd64\nmemory: 2048", "0-3")
+        assert changed is True
+        assert new == "arch: amd64\nmemory: 2048\nlxc.cgroup2.cpuset.cpus: 0-3\n"
+        assert "2048lxc" not in new
+
+    def test_handles_a_config_with_no_snapshots(self):
+        new, changed = lxc_utils._set_cpuset_line("arch: amd64\n", "0-3")
+        assert changed is True
+        assert new == "arch: amd64\nlxc.cgroup2.cpuset.cpus: 0-3\n"
+
+
+class TestConfPathGuard:
+    """_is_expected_conf_path: the guard that rejected every real path."""
+
+    def test_accepts_the_path_pmxcfs_actually_produces(self):
+        assert lxc_utils._is_expected_conf_path(
+            "/etc/pve/nodes/pve1/lxc/100.conf", "100"
+        ), (
+            "/etc/pve/lxc is documented as a symlink to nodes/<node>/lxc/, so "
+            "this is what realpath returns on every node"
+        )
+
+    def test_accepts_the_unresolved_path(self):
+        assert lxc_utils._is_expected_conf_path("/etc/pve/lxc/100.conf", "100")
+
+    def test_rejects_a_path_outside_pve(self):
+        assert not lxc_utils._is_expected_conf_path("/tmp/evil/100.conf", "100")
+
+    def test_rejects_another_containers_config(self):
+        assert not lxc_utils._is_expected_conf_path(
+            "/etc/pve/nodes/pve1/lxc/999.conf", "100"
+        )
+
+    def test_rejects_a_deeper_path_under_nodes(self):
+        assert not lxc_utils._is_expected_conf_path(
+            "/etc/pve/nodes/pve1/lxc/sub/100.conf", "100"
+        )
+
+    def test_rejects_a_node_name_containing_a_separator(self):
+        assert not lxc_utils._is_expected_conf_path(
+            "/etc/pve/nodes/a/b/lxc/100.conf", "100"
+        )
+
+
+@pytest.mark.asyncio
+class TestLocalWrite:
+    async def test_writes_through_a_symlinked_directory(self, tmp_path):
+        """
+        The whole local path, against a replica of the documented layout. The
+        old guard required realpath to still start with /etc/pve/lxc/, which is
+        false on every node, so this write was refused as a symlink attack.
+        """
+        node_dir = tmp_path / "nodes" / "pve1" / "lxc"
+        node_dir.mkdir(parents=True)
+        conf = node_dir / "100.conf"
+        conf.write_text(CONFIG_WITH_SNAPSHOT)
+        link = tmp_path / "lxc"
+        link.symlink_to(node_dir)
+
+        lxc_utils._applied_pinning.clear()
+        cfg = MagicMock()
+        cfg.defaults.use_remote_proxmox = False
+
+        with patch("lxc_utils.get_app_config", return_value=cfg), \
+             patch("lxc_utils._container_conf_path", return_value=str(link / "100.conf")), \
+             patch("lxc_utils._is_expected_conf_path", return_value=True):
+            assert await lxc_utils.apply_cpu_pinning("100", "0-3") is True
+
+        written = conf.read_text()
+        live = written.split("[before-upgrade]")[0]
+        assert "lxc.cgroup2.cpuset.cpus: 0-3" in live
+        assert "lxc.cgroup2.cpuset.cpus: 8-11" in written.split("[before-upgrade]")[1]
+
+    async def test_refuses_an_unexpected_path(self, tmp_path):
+        conf = tmp_path / "100.conf"
+        conf.write_text("arch: amd64\n")
+        lxc_utils._applied_pinning.clear()
+        cfg = MagicMock()
+        cfg.defaults.use_remote_proxmox = False
+
+        with patch("lxc_utils.get_app_config", return_value=cfg), \
+             patch("lxc_utils._container_conf_path", return_value=str(conf)):
+            assert await lxc_utils.apply_cpu_pinning("100", "0-3") is False
+        assert conf.read_text() == "arch: amd64\n"
+
+
+@pytest.mark.asyncio
+class TestRemoteWrite:
+    async def test_the_write_reaches_the_node(self):
+        lxc_utils._applied_pinning.clear()
+        cfg = MagicMock()
+        cfg.defaults.use_remote_proxmox = True
+
+        with patch("lxc_utils.get_app_config", return_value=cfg), \
+             patch("lxc_utils.run_command", new_callable=AsyncMock,
+                   return_value=CONFIG_WITH_SNAPSHOT.strip()), \
+             patch("lxc_utils.run_command_with_input", new_callable=AsyncMock,
+                   return_value=True) as write:
+            assert await lxc_utils.apply_cpu_pinning("100", "0-3") is True
+
+        written = write.await_args.args[1]
+        live = written.split("[before-upgrade]")[0]
+        assert "lxc.cgroup2.cpuset.cpus: 0-3" in live
+        assert "512lxc" not in written, "the stripped trailing newline was not restored"
+
+    async def test_a_failed_write_is_not_recorded_as_applied(self):
+        """
+        _applied_pinning is consulted before every attempt, so recording a
+        failure means never retrying for the life of the process.
+        """
+        lxc_utils._applied_pinning.clear()
+        cfg = MagicMock()
+        cfg.defaults.use_remote_proxmox = True
+
+        with patch("lxc_utils.get_app_config", return_value=cfg), \
+             patch("lxc_utils.run_command", new_callable=AsyncMock,
+                   return_value="arch: amd64"), \
+             patch("lxc_utils.run_command_with_input", new_callable=AsyncMock,
+                   return_value=False):
+            assert await lxc_utils.apply_cpu_pinning("100", "0-3") is False
+        assert "100" not in lxc_utils._applied_pinning
+
+    async def test_no_write_when_the_live_pin_is_already_correct(self):
+        lxc_utils._applied_pinning.clear()
+        cfg = MagicMock()
+        cfg.defaults.use_remote_proxmox = True
+
+        with patch("lxc_utils.get_app_config", return_value=cfg), \
+             patch("lxc_utils.run_command", new_callable=AsyncMock,
+                   return_value="arch: amd64\nlxc.cgroup2.cpuset.cpus: 0-3"), \
+             patch("lxc_utils.run_command_with_input", new_callable=AsyncMock) as write:
+            assert await lxc_utils.apply_cpu_pinning("100", "0-3") is True
+        write.assert_not_awaited()


### PR DESCRIPTION
Fixes the four defects in #77. All independent of the topology detection in #75, and all silent: on the local path the only signal was one `Symlink attack on config path` line at ERROR, and on the remote path there was none at all.

## 1. The guard rejected the only path that exists

```python
if not real_conf.startswith('/etc/pve/lxc/'):
    logger.error("Symlink attack on config path: ...")
    return False
```

Proxmox documents `/etc/pve/lxc` as a symbolic link to `nodes/<LOCAL_HOST_NAME>/lxc/`, so on every node:

```
conf_path  /etc/pve/lxc/100.conf
realpath   /etc/pve/nodes/pve1/lxc/100.conf   -> startswith("/etc/pve/lxc/") is False
```

Every local write was refused. The guard now accepts the documented target and still rejects a path outside `/etc/pve`, another container's config, a deeper path under `nodes/`, and a node name containing a separator.

## 2. The remote branch wrote on the wrong machine

It read the config over SSH, rebuilt it correctly, and handed it to a **local** `create_subprocess_exec("tee", conf_path)`. The node was never written, and on a daemon host that happens to have `/etc/pve/lxc`, the remote container's config was written into the local node's directory.

Writing remotely needs stdin, which `AsyncSSHPool` did not have, so it grows `run_command_with_input`. The content goes down the channel's stdin rather than the command line, for the same reason the existing code avoids `sed` and `sh -c`: a here-document or an `echo` would let the payload be parsed as shell.

## 3. The remote read lost its trailing newline

`run_command` strips its output, both locally and over SSH. Appending to it produced:

```
swap: 512lxc.cgroup2.cpuset.cpus: 0-3
```

corrupting the last key of the live section.

## 4. The pin landed inside a snapshot

`pct` stores each snapshot as a `[name]` section holding a full copy of the config. The rewrite treated the file as flat, so:

- the appended line went after the last snapshot header, where it has no effect on the running container
- a `cpuset` line found **inside a snapshot** was taken as proof the live section already had one, so the live section never got one
- `_applied_pinning` recorded success either way, so it was never retried for the life of the process

The rewrite is now one pure function operating on the live section only, shared by both paths. That also removes a divergence nobody would have noticed: the local branch matched with `line.startswith` and the remote with `stripped.startswith`.

## Tests

18 new, against a config with a snapshot in it, which is the shape that got it wrong. Not vacuous:

```
restore the old symlink guard      -> 1 failure
restore the flat rewrite           -> 5 failures
```

`test_remote_append_via_tee` was **asserting the defect**: it mocked `asyncio.create_subprocess_exec` on the remote path, so the local-write bug made it pass. It now asserts that the write goes through the channel that reaches the node, with the stripped newline restored.

```
420 passed
```

## Not in this PR

**#78**, the missing validation of explicit ranges, needs the authoritative CPU set that #76 introduces, so it belongs after that lands.

**#76 itself.** This touches the same file but not the same function: #76's hunks stop at line 380 and `apply_cpu_pinning` starts at 387. They are adjacent, so whichever lands second may want a trivial rebase. #76 is still a draft, and it is the fix for #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)