### PR TITLE
ci: run the test suite, on the versions this actually runs on

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,14 @@ name: Tests
 # change that broke a test reached main with every check green. That includes
 # the tests covering CPU pinning, a feature that writes to the configuration of
 # running containers.
+#
+# The matrix is 3.10 through 3.14, which is not what pylint.yml declared.
+# 3.9 is gone because the daemon does not run there: `asyncio.Lock()` binds
+# `get_event_loop()` at construction before 3.10, and lxc_utils builds one at
+# module scope, so it binds a loop that `asyncio.run()` then replaces. 3.13 and
+# 3.14 are new because lxc_autoscale/Dockerfile ships `python:3.14-slim`, so
+# the version that actually runs in production was the one version nobody
+# tested. pylint.yml now declares the same range.
 on:
   push:
     branches: ["main"]
@@ -21,12 +29,12 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
-      # Every version is run even when one fails: "it breaks on 3.9" and "it
+      # Every version is run even when one fails: "it breaks on 3.10" and "it
       # breaks everywhere" are different problems and the matrix should say
       # which one it is.
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,56 @@
+name: Tests
+
+# The repository has carried a test suite for some time and CI never ran it.
+# pylint.yml is the only other Python workflow and it runs pylint alone, so a
+# change that broke a test reached main with every check green. That includes
+# the tests covering CPU pinning, a feature that writes to the configuration of
+# running containers.
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      # Every version is run even when one fails: "it breaks on 3.9" and "it
+      # breaks everywhere" are different problems and the matrix should say
+      # which one it is.
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache pip packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+
+    - name: Run the test suite
+      env:
+        PYTHONPATH: ${{ github.workspace }}/lxc_autoscale
+      run: pytest tests/ -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,8 @@
 # same packages a test run does.
 pytest>=8.0
 pytest-asyncio>=0.23
+
+# tests/test_coverage_boost.py exercises the REST backend. proxmoxer is an
+# optional runtime dependency, commented out in requirements.txt, but a test
+# that covers the backend needs it present.
+proxmoxer>=2.0,<3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# Test dependencies. The suite is 423 tests over 21 files and nothing in CI ran
+# any of them, because pytest was never installed: the only Python workflow
+# installed pylint and requirements.txt, and this file did not exist.
+#
+# pylint.yml already installs it when present, so a lint run now imports the
+# same packages a test run does.
+pytest>=8.0
+pytest-asyncio>=0.23

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -21,15 +21,34 @@ class TestCreateBackend:
         assert isinstance(backend, CLIBackend)
 
     def test_api_backend_requires_proxmoxer(self):
+        """
+        backend: api without proxmoxer installed must say so, not fail later.
+
+        This used to simulate the missing package with
+        `patch.dict('sys.modules', {'proxmoxer': None})`, inside a try/except
+        that swallowed three exception types and asserted nothing, so the test
+        passed whatever happened, including on a success.
+
+        It also broke a different test. `patch.dict` restores a dict by clearing
+        it and writing the snapshot back, so every module first imported inside
+        the block is dropped from `sys.modules` on exit while the parent package
+        keeps its attribute pointing at the old object. `backends.api` is
+        imported inside the block, and afterwards
+        `patch('backends.api.ProxmoxAPI')` and `import backends.api` no longer
+        resolve to the same module: the patch lands on one, the code under test
+        reads the other. `TestRESTBackend` then ran against the real proxmoxer
+        and opened an HTTPS connection to the address in its own fixture,
+        waiting five seconds for it to time out.
+
+        Setting the name the module actually reads is enough, and it leaves
+        `sys.modules` alone.
+        """
         cfg = MagicMock()
         cfg.defaults.backend = "api"
         cfg.defaults.proxmox_api.host = "192.168.1.1"
-        # If proxmoxer is not installed, should raise
-        with patch.dict('sys.modules', {'proxmoxer': None}):
-            try:
+        with patch('backends.api.ProxmoxAPI', None):
+            with pytest.raises(RuntimeError, match="proxmoxer is required"):
                 create_backend(cfg)
-            except (RuntimeError, ImportError, TypeError):
-                pass  # expected if proxmoxer unavailable
 
 
 class TestCLIBackendEdgeCases:


### PR DESCRIPTION
Found while reviewing #76.

## The repository has 423 tests and CI runs none of them

```
$ pytest tests/ -q --collect-only | tail -1
423 tests collected
```

`pylint.yml` is the only other Python workflow, and it runs pylint alone. It does carry this line:

```yaml
if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
```

and `requirements-dev.txt` did not exist, so pytest was never installed either. A change that broke a test reached `main` with every check green.

That includes `tests/test_cpu_pinning_write.py`, added in #83, and the 20 tests #76 adds. It also includes every test covering the code that writes `lxc.cgroup2.cpuset.cpus` into the configuration of a running container, which is the one place in this daemon where being wrong can stop a container from starting.

## Running them found three things

### 1. The declared matrix was wrong at both ends

It was 3.9 through 3.12; it is now 3.10 through 3.14.

**3.9 is gone because the daemon does not run there.** Before 3.10, `asyncio.Lock` binds `events.get_event_loop()` inside `__init__`:

```python
# Lib/asyncio/locks.py, v3.9.18
def __init__(self, *, loop=None):
    ...
    self._loop = events.get_event_loop()
```

From 3.10 it inherits `_LoopBoundMixin` and binds lazily on first use. `lxc_utils.py` builds one at module scope (`_json_log_lock = asyncio.Lock()`), so on 3.9 it binds whatever loop exists at import time and `asyncio.run()` then creates a different one. Four tests fail there for exactly that reason, and it is not a test artefact.

**3.13 and 3.14 are new because `lxc_autoscale/Dockerfile` ships `python:3.14-slim`.** The version that actually runs in production was the one version the matrix did not name.

### 2. `proxmoxer` was a missing test dependency

`tests/test_coverage_boost.py` exercises the REST backend. `proxmoxer` is optional at runtime and commented out in `requirements.txt`, and the test fails without it.

### 3. A test that cannot fail was making another test dial out to the network

`test_api_backend_requires_proxmoxer` simulated a missing package like this:

```python
with patch.dict('sys.modules', {'proxmoxer': None}):
    try:
        create_backend(cfg)
    except (RuntimeError, ImportError, TypeError):
        pass  # expected if proxmoxer unavailable
```

It asserts nothing. Three exception types are swallowed and a success is also a pass, so the test reports green whatever `create_backend` does.

It also broke a test two files away. `patch.dict` restores a dict by clearing it and writing its snapshot back, so a module first imported inside the block is dropped from `sys.modules` on exit while the parent package keeps its attribute pointing at the old object. `backends.api` is imported inside that block, and afterwards `patch('backends.api.ProxmoxAPI')` and `import backends.api` no longer resolve to the same module object: the patch lands on one, the code under test reads the other.

The visible result is a unit test opening an HTTPS connection to the address in its own fixture and waiting five seconds for it to time out:

```
ERROR backends.api:api.py:67 API list_containers failed:
HTTPSConnectionPool(host='192.168.1.1', port=8006): Max retries exceeded
... ConnectTimeoutError ... connect timeout=5
```

Confirmed by printing the attribute from inside the patch: within `with patch('backends.api.ProxmoxAPI')`, `backends.api.ProxmoxAPI` was still `<class 'proxmoxer.core.ProxmoxAPI'>`.

It reproduces on 3.10 and not on the other versions, because collection order there imports `backends.api` for the first time inside the block. Nothing about it is specific to 3.10 and the ordering that triggers it is incidental.

The fix sets the name the module actually reads, leaves `sys.modules` alone, and lets the test assert the contract it is named for:

```python
with patch('backends.api.ProxmoxAPI', None):
    with pytest.raises(RuntimeError, match="proxmoxer is required"):
        create_backend(cfg)
```

## What this adds

- `.github/workflows/tests.yml`, matrix 3.10 to 3.14, `fail-fast: false` because "it breaks on 3.10" and "it breaks everywhere" are different problems and the matrix should say which one it is.
- `requirements-dev.txt` with pytest, pytest-asyncio and proxmoxer.
- `pylint.yml`'s matrix realigned to the same range, so the two workflows stop disagreeing about which Pythons this supports.
- One test rewritten, described above.

423 tests pass on 3.10 and on 3.14 locally. No daemon code is modified.

If you would rather keep 3.9, that is a separate change: the two module-scope `asyncio.Lock()` constructions have to become lazy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)